### PR TITLE
Include `content-type` header on directory default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install latest Rust stable toolchain
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.86
           default: true
           components: clippy, rustfmt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,6 @@ jobs:
       - name: Install Wasm Rust target
         run: rustup target add wasm32-wasip1
 
-      - name: Install spin-test
-        run: |
-          mkdir spin-install
-          cd spin-install
-          curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash
-          sudo mv spin /usr/local/bin/
-          spin plugin install -u https://github.com/fermyon/spin-test/releases/download/canary/spin-test.json --yes
-
       - name: Install cargo-component
         uses: baptiste0928/cargo-install@v3
         with:
@@ -40,6 +32,5 @@ jobs:
       - name: Make
         run: |
           make
-          make spin-test
         env:
           RUST_LOG: spin=trace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       - name: set the release version (tag)
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: Install latest Rust stable toolchain
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.86
           default: true
           components: clippy, rustfmt
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,13 +381,20 @@ impl FileServer {
 
     /// Return the media type of the file based on the path.
     fn mime(path: &str) -> Option<String> {
-        match path {
+        let mut mime = match path {
             FAVICON_ICO_FILENAME => mime_guess::from_ext("ico"),
             FAVICON_PNG_FILENAME => mime_guess::from_ext("png"),
             _ => mime_guess::from_path(path),
         }
-        .first()
-        .map(|m| m.to_string())
+        .first();
+
+        if mime.is_none() {
+            if let FileServerPath::Physical(p) = Self::resolve(path) {
+                mime = mime_guess::from_path(&p).first();
+            }
+        }
+
+        mime.map(|m| m.to_string())
     }
 
     fn make_headers(path: &str, enc: SupportedEncoding, etag: &str) -> Vec<(String, Vec<u8>)> {


### PR DESCRIPTION
Fixes #64 

This wasn't CIing because Rust was unpinned so there were random clippies: I've therefore also pinned Rust with apologies for the unrelated change.  _(Edit: also had to turn off spin-test: it's not working right now and Ryan and Alex believe it's a non-trivial fix at the spin-test end.)_
